### PR TITLE
Update conda files with exact versions

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -4,11 +4,11 @@ channels:
   - conda-forge
 dependencies:
   - python=3.10.17
-  - hydra-core
-  - omegaconf
-  - python-dotenv
-  - pyyaml
-  - pip
+  - hydra-core=1.3.2
+  - omegaconf=2.3.0
+  - python-dotenv=1.1.0
+  - pyyaml=6.0.2
+  - pip=25.1.1
   - pip:
-      - mlflow-skinny
-      - wandb
+      - mlflow-skinny==2.22.0
+      - wandb==0.19.11

--- a/environment.yml
+++ b/environment.yml
@@ -15,11 +15,11 @@ dependencies:
   - scikit-learn=1.6.1   # Machine learning library for model training and evaluation
   - scipy=1.15.2         # Core scientific computation
   - pip=25.1.1           # Allows pip-only packages to be installed below
-  - hydra-core           # Core library for Hydra configuration management
-  - omegaconf            # Configuration management library for structured configs
-  - dvc                  # Data Version Control for managing ML datasets and models
-  - dvc-s3               # DVC extension for S3 storage support (for dataset management)
-  - awscli               # AWS Command Line Interface for interacting with AWS services
+  - hydra-core=1.3.2           # Core library for Hydra configuration management
+  - omegaconf=2.3.0            # Configuration management library for structured configs
+  - dvc=3.59.2                 # Data Version Control for managing ML datasets and models
+  - dvc-s3=3.2.0               # DVC extension for S3 storage support (for dataset management)
+  - awscli=2.27.27             # AWS Command Line Interface for interacting with AWS services
   - pip:
       - pytest-cov==6.1.1  # Test coverage reporting for code quality and completeness
       - black==25.1.0      # Code formatting to enforce style and readability

--- a/setup.sh
+++ b/setup.sh
@@ -12,11 +12,11 @@ pip install \
     pytest-dotenv==0.5.2 \
     scikit-learn==1.6.1 \
     scipy==1.15.2 \
-    hydra-core \
-    omegaconf \
-    dvc \
-    dvc-s3 \
-    awscli \
+    hydra-core==1.3.2 \
+    omegaconf==2.3.0 \
+    dvc==3.59.2 \
+    dvc-s3==3.2.0 \
+    awscli==2.27.27 \
     pytest-cov==6.1.1 \
     black==25.1.0 \
     flake8==7.2.0 \

--- a/src/data_load/conda.yml
+++ b/src/data_load/conda.yml
@@ -5,12 +5,12 @@ channels:
 
 dependencies:
   - python=3.10.17
-  - pandas
-  - hydra-core
-  - omegaconf
-  - python-dotenv
-  - pyyaml
-  - openpyxl
-  - pip
+  - pandas=2.2.3
+  - hydra-core=1.3.2
+  - omegaconf=2.3.0
+  - python-dotenv=1.1.0
+  - pyyaml=6.0.2
+  - openpyxl=3.1.5
+  - pip=25.1.1
   - pip:
-      - wandb
+      - wandb==0.19.11

--- a/src/data_validation/conda.yml
+++ b/src/data_validation/conda.yml
@@ -2,11 +2,11 @@ name: data_validation
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
-  - pandas
-  - pyyaml
-  - hydra-core
-  - omegaconf
-  - python-dotenv
+  - python=3.10.17
+  - pandas=2.2.3
+  - pyyaml=6.0.2
+  - hydra-core=1.3.2
+  - omegaconf=2.3.0
+  - python-dotenv=1.1.0
   - pip:
-      - wandb
+      - wandb==0.19.11

--- a/src/evaluation/conda.yml
+++ b/src/evaluation/conda.yml
@@ -3,14 +3,14 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.10
-  - pandas
-  - scikit-learn
+  - python=3.10.17
+  - pandas=2.2.3
+  - scikit-learn=1.6.1
   - matplotlib
-  - hydra-core
-  - omegaconf
-  - python-dotenv
-  - pyyaml
-  - pip
+  - hydra-core=1.3.2
+  - omegaconf=2.3.0
+  - python-dotenv=1.1.0
+  - pyyaml=6.0.2
+  - pip=25.1.1
   - pip:
-      - wandb
+      - wandb==0.19.11

--- a/src/features/conda.yml
+++ b/src/features/conda.yml
@@ -2,13 +2,13 @@ name: feature_eng
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
-  - pandas
-  - scikit-learn
-  - hydra-core
-  - omegaconf
-  - python-dotenv
-  - pyyaml
-  - pip
+  - python=3.10.17
+  - pandas=2.2.3
+  - scikit-learn=1.6.1
+  - hydra-core=1.3.2
+  - omegaconf=2.3.0
+  - python-dotenv=1.1.0
+  - pyyaml=6.0.2
+  - pip=25.1.1
   - pip:
-      - wandb
+      - wandb==0.19.11

--- a/src/inference/conda.yml
+++ b/src/inference/conda.yml
@@ -3,13 +3,13 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.10
-  - pandas
-  - scikit-learn
-  - hydra-core
-  - omegaconf
-  - python-dotenv
-  - pyyaml
-  - pip
+  - python=3.10.17
+  - pandas=2.2.3
+  - scikit-learn=1.6.1
+  - hydra-core=1.3.2
+  - omegaconf=2.3.0
+  - python-dotenv=1.1.0
+  - pyyaml=6.0.2
+  - pip=25.1.1
   - pip:
-      - wandb
+      - wandb==0.19.11

--- a/src/model/conda.yml
+++ b/src/model/conda.yml
@@ -3,13 +3,13 @@ channels:
   - conda-forge
 
 dependencies:
-  - python=3.10
-  - pandas
-  - scikit-learn
-  - hydra-core
-  - omegaconf
-  - python-dotenv
-  - pyyaml
-  - pip
+  - python=3.10.17
+  - pandas=2.2.3
+  - scikit-learn=1.6.1
+  - hydra-core=1.3.2
+  - omegaconf=2.3.0
+  - python-dotenv=1.1.0
+  - pyyaml=6.0.2
+  - pip=25.1.1
   - pip:
-      - wandb
+      - wandb==0.19.11

--- a/src/preprocess/conda.yml
+++ b/src/preprocess/conda.yml
@@ -2,13 +2,13 @@ name: preprocess
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
-  - pandas
-  - scikit-learn
-  - hydra-core
-  - omegaconf
-  - python-dotenv
-  - pyyaml
-  - pip
+  - python=3.10.17
+  - pandas=2.2.3
+  - scikit-learn=1.6.1
+  - hydra-core=1.3.2
+  - omegaconf=2.3.0
+  - python-dotenv=1.1.0
+  - pyyaml=6.0.2
+  - pip=25.1.1
   - pip:
-      - wandb
+      - wandb==0.19.11


### PR DESCRIPTION
## Summary
- pin versions in environment.yml
- pin versions for orchestration environment
- keep modules' conda.yml files minimal but version pinned
- pin versions in setup.sh to match working conda list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6849aefac5c0832f94aee045b70ece0b