### PR TITLE
Add FastAPI service with prediction endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import sys
+import pickle
+from pathlib import Path
+from typing import Dict, Optional
+
+import pandas as pd
+import yaml
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+# Ensure src/ is on the Python path to import preprocessing utilities
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from preprocess.preprocessing import get_output_feature_names
+
+app = FastAPI(title="Opioid Abuse Prediction API")
+
+# Load configuration and artifacts once at startup
+with open(PROJECT_ROOT / "config.yaml", "r", encoding="utf-8") as f:
+    CONFIG: Dict = yaml.safe_load(f)
+
+RAW_FEATURES = CONFIG.get("raw_features", [])
+ENGINEERED = CONFIG.get("features", {}).get("engineered", [])
+ARTIFACTS = CONFIG.get("artifacts", {})
+
+MODEL_PATH = PROJECT_ROOT / ARTIFACTS.get("model_path", "models/model.pkl")
+PREPROC_PATH = PROJECT_ROOT / ARTIFACTS.get(
+    "preprocessing_pipeline", "models/preprocessing_pipeline.pkl"
+)
+
+with open(PREPROC_PATH, "rb") as f:
+    PIPELINE = pickle.load(f)
+
+with open(MODEL_PATH, "rb") as f:
+    MODEL = pickle.load(f)
+
+FEATURE_NAMES = get_output_feature_names(
+    preprocessor=PIPELINE, input_features=RAW_FEATURES, config=CONFIG
+)
+SELECTED_INDICES = [FEATURE_NAMES.index(f) for f in ENGINEERED if f in FEATURE_NAMES]
+
+
+class PredictionRequest(BaseModel):
+    """Input schema for model inference."""
+
+    rx_ds: int = Field(..., example=330)
+    A: int = Field(..., example=0)
+    B: int = Field(..., example=0)
+    C: int = Field(..., example=0)
+    D: int = Field(..., example=1)
+    E: int = Field(..., example=1)
+    F: int = Field(..., example=1)
+    H: int = Field(..., example=0)
+    I: int = Field(..., example=1)
+    J: int = Field(..., example=1)
+    K: int = Field(..., example=0)
+    L: int = Field(..., example=1)
+    M: int = Field(..., example=1)
+    N: int = Field(..., example=1)
+    R: int = Field(..., example=0)
+    S: int = Field(..., example=0)
+    T: int = Field(..., example=0)
+    V: int = Field(..., example=0)
+
+
+@app.get("/")
+async def read_root() -> Dict[str, str]:
+    """Simple greeting for sanity check."""
+    return {"message": "Welcome to the opioid abuse prediction API"}
+
+
+@app.get("/health")
+async def health() -> Dict[str, str]:
+    """Health check endpoint used in tests."""
+    return {"status": "ok"}
+
+
+@app.post("/predict")
+async def predict(request: PredictionRequest) -> Dict[str, Optional[float]]:
+    """Return model prediction for a single sample."""
+    data = request.dict()
+    df = pd.DataFrame([data])
+    df.rename(columns={"rx_ds": "rx ds"}, inplace=True)
+    X_raw = df[RAW_FEATURES]
+    X_proc = PIPELINE.transform(X_raw)
+    if SELECTED_INDICES:
+        X_proc = X_proc[:, SELECTED_INDICES]
+    pred = MODEL.predict(X_proc)[0]
+    proba: Optional[float] = None
+    if hasattr(MODEL, "predict_proba"):
+        proba = float(MODEL.predict_proba(X_proc)[:, 1][0])
+    return {"prediction": float(pred), "prediction_proba": proba}
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,6 @@ pytest-dotenv==0.5.2
 pytest-cov==6.1.1
 black==25.1.0
 flake8==7.2.0
+fastapi==0.110.0
+uvicorn==0.29.0
+requests==2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ dvc==3.59.2
 dvc-s3==3.2.0
 mlflow-skinny==2.22.0
 wandb==0.19.11
+fastapi==0.110.0
+uvicorn==0.29.0
+requests==2.32.3

--- a/scripts/call_api.py
+++ b/scripts/call_api.py
@@ -1,0 +1,35 @@
+"""Simple helper to POST sample data to the FastAPI service."""
+
+from __future__ import annotations
+
+import json
+import requests
+
+SAMPLE_PAYLOAD = {
+    "rx_ds": 330,
+    "A": 0,
+    "B": 0,
+    "C": 0,
+    "D": 1,
+    "E": 1,
+    "F": 1,
+    "H": 0,
+    "I": 1,
+    "J": 1,
+    "K": 0,
+    "L": 1,
+    "M": 1,
+    "N": 1,
+    "R": 0,
+    "S": 0,
+    "T": 0,
+    "V": 0,
+}
+
+if __name__ == "__main__":
+    resp = requests.post("http://localhost:8000/predict", json=SAMPLE_PAYLOAD)
+    print("Status:", resp.status_code)
+    try:
+        print("Response:", json.dumps(resp.json(), indent=2))
+    except ValueError:
+        print("Invalid JSON response")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_health_endpoint():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- create a basic FastAPI application for model serving
- load model artifacts and run inference via `/predict`
- provide `/` greeting and `/health` endpoint
- add example client script using `requests`
- include FastAPI and related deps in requirements
- test the health endpoint with FastAPI `TestClient`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_6849ea72e7a0832fa8fd2d447802ceec