### PR TITLE
Update env with API packages

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,7 @@ dependencies:
       - flake8==7.2.0      # Linting to check code for errors and best practices
       - mlflow-skinny==2.22.0  # Experiment tracking and model management
       - wandb==0.19.11         # Weights & Biases for experiment tracking and visualization
+      - fastapi==0.115.12      # Framework for building RESTful APIs
+      - uvicorn==0.34.3        # ASGI server for FastAPI
+      - requests==2.32.4       # Synchronous HTTP client
+      - httpx==0.28.1          # Async HTTP client

--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,11 @@ pip install \
     black==25.1.0 \
     flake8==7.2.0 \
     mlflow-skinny==2.22.0 \
-    wandb==0.19.11
+    wandb==0.19.11 \
+    fastapi==0.115.12 \
+    uvicorn==0.34.3 \
+    requests==2.32.4 \
+    httpx==0.28.1
 
 # Add src to PYTHONPATH for this session
 export PYTHONPATH="$(pwd)/src:$PYTHONPATH"


### PR DESCRIPTION
## Summary
- add FastAPI, Uvicorn, Requests and HTTPX to conda environment
- install same dependencies in setup.sh for local setup consistency

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849f2804368832f8aebbef22fe4cbd2