### PR TITLE
Add FastAPI API with health check

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+import pickle
+import yaml
+from pathlib import Path
+import pandas as pd
+from preprocess.preprocessing import get_output_feature_names
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = PROJECT_ROOT / "config.yaml"
+
+with CONFIG_PATH.open("r", encoding="utf-8") as fh:
+    CONFIG = yaml.safe_load(fh)
+
+PIPELINE_PATH = PROJECT_ROOT / CONFIG.get("artifacts", {}).get(
+    "preprocessing_pipeline", "models/preprocessing_pipeline.pkl"
+)
+MODEL_PATH = PROJECT_ROOT / CONFIG.get("artifacts", {}).get(
+    "model_path", "models/model.pkl"
+)
+
+with PIPELINE_PATH.open("rb") as fh:
+    PIPELINE = pickle.load(fh)
+
+with MODEL_PATH.open("rb") as fh:
+    MODEL = pickle.load(fh)
+
+RAW_FEATURES = CONFIG.get("raw_features", [])
+ENGINEERED = CONFIG.get("features", {}).get("engineered", [])
+
+app = FastAPI()
+
+
+class PredictionInput(BaseModel):
+    rx_ds: int = Field(..., alias="rx ds")
+    A: int
+    B: int
+    C: int
+    D: int
+    E: int
+    F: int
+    H: int
+    I: int
+    J: int
+    K: int
+    L: int
+    M: int
+    N: int
+    R: int
+    S: int
+    T: int
+    V: int
+
+    class Config:
+        allow_population_by_field_name = True
+        schema_extra = {
+            "example": {
+                "rx_ds": 100,
+                "A": 0,
+                "B": 1,
+                "C": 0,
+                "D": 0,
+                "E": 1,
+                "F": 0,
+                "H": 0,
+                "I": 0,
+                "J": 1,
+                "K": 0,
+                "L": 0,
+                "M": 0,
+                "N": 1,
+                "R": 0,
+                "S": 0,
+                "T": 0,
+                "V": 0,
+            }
+        }
+
+
+@app.get("/")
+def root():
+    return {"message": "Welcome to the opioid abuse prediction API"}
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/predict")
+def predict(payload: PredictionInput):
+    data = payload.dict(by_alias=True)
+    df = pd.DataFrame([data])
+    X_raw = df[RAW_FEATURES]
+    X_proc = PIPELINE.transform(X_raw)
+    if ENGINEERED:
+        feature_names = get_output_feature_names(
+            preprocessor=PIPELINE,
+            input_features=RAW_FEATURES,
+            config=CONFIG,
+        )
+        indices = [feature_names.index(f) for f in ENGINEERED if f in feature_names]
+        X_proc = X_proc[:, indices]
+    pred = MODEL.predict(X_proc)[0]
+    proba = MODEL.predict_proba(X_proc)[0, 1] if hasattr(MODEL, "predict_proba") else None
+    return {"prediction": int(pred), "probability": float(proba) if proba is not None else None}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 env_files = .env
-pythonpath = src
+pythonpath = src app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ black==25.1.0
 flake8==7.2.0
 pyyaml==6.0.2
 httpx==0.27.0
+fastapi==0.115.12
+uvicorn==0.34.3

--- a/scripts/call_api.py
+++ b/scripts/call_api.py
@@ -1,0 +1,25 @@
+import argparse
+import pandas as pd
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Call prediction API")
+    parser.add_argument("--url", required=True, help="Prediction endpoint URL")
+    parser.add_argument("--input", required=True, help="CSV file with a single record")
+    args = parser.parse_args()
+
+    df = pd.read_csv(args.input)
+    if len(df) == 0:
+        raise ValueError("Input CSV must contain at least one row")
+    data = df.iloc[0].to_dict()
+    response = requests.post(args.url, json=data)
+    print("Status code:", response.status_code)
+    try:
+        print("Response:", response.json())
+    except ValueError:
+        print("Non-JSON response")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,14 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_health():
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- create `app` package with FastAPI inference API
- add prediction caller script
- support `app` in `pytest.ini`
- add dependencies for FastAPI
- test `/health` endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849f4435bec832fb9cb8431bf7d23b5