### PR TITLE
Add DataFrame inference API with batch endpoint

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,3 +12,32 @@ def test_health():
     resp = client.get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
+
+
+def test_predict_batch():
+    payload = {
+        "rx ds": 100,
+        "A": 0,
+        "B": 1,
+        "C": 0,
+        "D": 0,
+        "E": 1,
+        "F": 0,
+        "H": 0,
+        "I": 0,
+        "J": 1,
+        "K": 0,
+        "L": 0,
+        "M": 0,
+        "N": 1,
+        "R": 0,
+        "S": 0,
+        "T": 0,
+        "V": 0,
+    }
+    resp = client.post("/predict_batch", json=[payload, payload])
+    assert resp.status_code == 200
+    result = resp.json()
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert set(result[0].keys()) == {"prediction", "probability"}


### PR DESCRIPTION
## Summary
- implement `run_inference_df` to run predictions on an in-memory dataframe
- expose new `/predict_batch` endpoint in the FastAPI app
- add unit tests for DataFrame inference including error cases
- test the new batch API endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab950ad3c832fa0db1321be132448