### PR TITLE
Add Docker support for Render deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Ignore git and dvc history
+.git
+.dvc
+.dvcignore
+data.dvc
+
+# Ignore datasets and artifacts
+artifacts/
+data/
+models/
+logs/
+wandb/
+mlruns/
+outputs/
+notebooks/
+
+# Python cache
+__pycache__/
+*.py[cod]
+
+# Environment files
+.env
+*.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.10-slim
+
+WORKDIR /code
+
+# install dependencies first to leverage layer caching
+COPY requirements.txt requirements-dev.txt ./
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+
+# copy application code
+COPY app ./app
+COPY src ./src
+COPY config.yaml ./
+COPY main.py ./
+COPY MLproject ./
+COPY scripts ./scripts
+
+EXPOSE 8000
+
+HEALTHCHECK CMD curl --fail http://localhost:${PORT:-8000}/health || exit 1
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "${PORT:-8000}"]

--- a/README.md
+++ b/README.md
@@ -185,11 +185,22 @@ The `/predict` endpoint remains available for single-record requests.
 pytest
 ```
 
+## 🐳 Docker Deployment
+
+Build the Docker image and run the API locally:
+```bash
+docker build -t opioid-api .
+docker run -p 8000:8000 opioid-api
+```
+The server respects the `PORT` environment variable (default `8000`),
+making it compatible with platforms such as Render. See `render.yaml`
+for a minimal deployment configuration.
+
 ---
 
 ## 📈 Next Steps
 
-- **Containerization:** Dockerize the project to ensure portability, reproducibility, and ease of deployment across environments
+- **CI/CD Enhancements:** Automate Docker image builds and publishing
 
 ---
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,8 @@
+services:
+  - type: web
+    name: mlops-api
+    env: docker
+    plan: free
+    dockerfilePath: Dockerfile
+    buildCommand: ""
+    startCommand: ""


### PR DESCRIPTION
## Summary
- provide Dockerfile exposing the FastAPI app
- add .dockerignore to keep images small
- define Render web service configuration
- document Docker usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684ac29fa2c0832f8614af75cac43859