### PR TITLE
Add automated W&B artifact download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.10-slim
 
 WORKDIR /code
+ENV PYTHONPATH=/code/src
 
 # install dependencies first to leverage layer caching
 COPY requirements.txt requirements-dev.txt ./
@@ -18,4 +19,4 @@ EXPOSE 8000
 
 HEALTHCHECK CMD curl --fail http://localhost:${PORT:-8000}/health || exit 1
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "${PORT:-8000}"]
+CMD ["sh", "-c", "python scripts/download_from_wandb.py && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/README.md
+++ b/README.md
@@ -192,6 +192,15 @@ Build the Docker image and run the API locally:
 docker build -t opioid-api .
 docker run -p 8000:8000 opioid-api
 ```
+Before building or running, set the following environment variables so the
+container can download the latest model from Weights & Biases:
+
+```bash
+export WANDB_PROJECT=<your-project>
+export WANDB_ENTITY=<your-entity>
+export WANDB_API_KEY=<your-api-key>
+```
+
 The server respects the `PORT` environment variable (default `8000`),
 making it compatible with platforms such as Render. See `render.yaml`
 for a minimal deployment configuration.

--- a/scripts/download_from_wandb.py
+++ b/scripts/download_from_wandb.py
@@ -1,0 +1,53 @@
+import os
+import shutil
+from pathlib import Path
+import wandb
+
+
+def download_artifacts(dest_dir: str | Path = "models") -> None:
+    """Download latest model and preprocessing pipeline from Weights & Biases.
+
+    Authentication uses the WANDB_API_KEY environment variable. The project and
+    entity are read from WANDB_PROJECT and WANDB_ENTITY.
+    """
+    dest = Path(dest_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    model_file = dest / "model.pkl"
+    pipeline_file = dest / "preprocessing_pipeline.pkl"
+    if model_file.exists() and pipeline_file.exists():
+        print("Model artifacts already exist. Skipping download.")
+        return
+
+    project = os.environ.get("WANDB_PROJECT")
+    entity = os.environ.get("WANDB_ENTITY")
+    api_key = os.environ.get("WANDB_API_KEY")
+    if not all([project, entity, api_key]):
+        raise EnvironmentError(
+            "WANDB_PROJECT, WANDB_ENTITY, and WANDB_API_KEY must be set"
+        )
+
+    wandb.login(key=api_key)
+    run = wandb.init(project=project, entity=entity, job_type="fetch-model", reinit=True)
+
+    model_art = run.use_artifact("model:latest")
+    model_dir = Path(model_art.download())
+    for name in ["model.pkl", "preprocessing_pipeline.pkl"]:
+        src = model_dir / name
+        if src.exists():
+            shutil.copy(src, dest / name)
+
+    # Also try explicit preprocessing_pipeline artifact if present
+    try:
+        pp_art = run.use_artifact("preprocessing_pipeline:latest")
+        pp_dir = Path(pp_art.download())
+        src = pp_dir / "preprocessing_pipeline.pkl"
+        if src.exists():
+            shutil.copy(src, pipeline_file)
+    except wandb.errors.CommError:
+        pass
+
+    run.finish()
+
+
+if __name__ == "__main__":
+    download_artifacts()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,11 @@
 import os
 import sys
+from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from app.main import app
+with patch("scripts.download_from_wandb.download_artifacts"):
+    from app.main import app
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- fetch latest model & preprocessing pipeline from W&B via new `scripts/download_from_wandb.py`
- run the download script before starting Uvicorn in Docker
- document required W&B env vars in README
- avoid network calls during tests by patching download function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2a1eb888832f826176952cbbfdbe